### PR TITLE
Standardization of documentation and request return

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ header = {
 ```json
 {
     "message": "User Successfully Added",
-    "userid": "user_id",
+    "id": "user_id",
     "token": "TOKEN value"
 }
 ```
@@ -392,6 +392,38 @@ header = {
       "realized": 0
   }
 ]
+```
+
+###### Warnings
+
+```json
+{
+  "message": "Payload Precondition Failed"
+}
+```
+
+```json
+{
+  "message": "Invalid or Missing Token"
+}
+```
+
+```json
+{
+  "message": "Invalid Arguments Number (Expected One)"
+}
+```
+
+```json
+{
+  "message": "Bad Request (Invalid Syntax)"
+}
+```
+
+```json
+{
+  "message": "Token Refused"
+}
 ```
 
 | Resource |      URI      |  Method  |

--- a/api/user/new/index.php
+++ b/api/user/new/index.php
@@ -67,7 +67,7 @@ try {
             if ($newUser[0]) {
                 echo json_encode(
                     ['message' => 'User Successfully Added',
-                        'userid' => $newUser[1],
+                        'id' => $newUser[1],
                         'token' => $newUser[2]]
                 );
 

--- a/src/User/UserModel.php
+++ b/src/User/UserModel.php
@@ -123,7 +123,7 @@ class UserModel
             $stmt->bindValue(':token', $token, \PDO::PARAM_STR);
             $stmt->execute();
 
-            $userId = self::$pdo->lastInsertId();
+            $userId = (int)self::$pdo->lastInsertId();
             self::$pdo->commit();
 
             return [true, $userId, $token];


### PR DESCRIPTION
- api/user/new/index.php
Line 70 - The "userid" value has been changed to "id" to keep the naming pattern;

- README #Resources (User)
Line 124 - The key name "userid" has been changed to "id" to keep the naming pattern;
Line 397 - The list of warnings has been inserted to maintain the documentation standard;

- src/User/UserModel.php
Line 126 - Convert created userid from string to int to keep the return pattern;